### PR TITLE
Add missing include (cstring)

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <algorithm>
 #include <array>
 #include <chrono>


### PR DESCRIPTION
The code uses `std::memcpy()`, which requires `<cstring>`. Without the include, clang-tidy complains about missing symbols for Windows/MinGW.