### PR TITLE
to avoid error LNK2019:Unresolved external symbol

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -49,6 +49,10 @@ extern "C" char *_strdup(const char *strSource);
 #  include <unistd.h>
 #endif // _WIN32
 
+#ifdef _MSC_VER
+#pragma comment(lib, "ws2_32.lib")
+#endif
+
 namespace http
 {
     class RequestError final: public std::logic_error


### PR DESCRIPTION
to avoid error LNK2019:Unresolved external symbol when using Visual Studio