### PR TITLE
Add Support for CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tests/tests.VC.db
 tests/tests.VC.VC.opendb
 tests/tests
 tests/tests.exe
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.8)
+project(HTTPRequest CXX)
+
+# Header only library will be interface. All properties get passed to targets that 'link' to it
+add_library(HTTPRequest INTERFACE)
+target_include_directories(HTTPRequest
+  INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+# Optionally build unit tests
+option(BUILD_TESTING "Build Unit Tests" OFF)
+if (BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,4 @@ if (BUILD_TESTING)
   enable_testing()
   add_subdirectory(tests)
 endif()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,4 @@ target_include_directories(HTTPRequest_tests
 add_test(test HTTPRequest_tests)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
                   DEPENDS HTTPRequest_tests)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+add_executable(HTTPRequest_tests
+  main.cpp
+  tests.cpp
+)
+
+target_link_libraries(HTTPRequest_tests
+  PRIVATE
+    HTTPRequest
+)
+
+target_include_directories(HTTPRequest_tests
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/external/Catch2/single_include
+)
+
+# Enable use of 'make test'
+add_test(test HTTPRequest_tests)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                  DEPENDS HTTPRequest_tests)


### PR DESCRIPTION
Hi,

I really like the project! It's lightweight and easy to use, and doesn't come with a ton of dependencies.

I've added support for cmake in this PR so this project can easily integrate with other cmake projects.

To build/run unit tests:
`mkdir build && cd build`
Generate Makefile and optionally build unit tests
`cmake -D BUILD_TESTING=ON <path_to_HTTPRequest_src>`
Make and run unit tests
`make test`


For other cmake projects to include this one, they can add this statement to their project

`add_subdirectory(<path_to_HTTPRequest>)`

Then 'link' it to their project

`target_link_libraries(my_target PRIVATE HTTPRequest)`

Now, the source of 'my_target' will get the proper -I flags, i.e. they can:
`#incude "HTTPRequest.hpp`

And the compiler will know where to look.